### PR TITLE
Reject on open failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,6 +164,7 @@ Phantasma.prototype.open = function (url) {
     if(!self.page) return reject('tried to open before page created');
 
     self.page.open(url, function (status) {
+      if (status === 'fail') return reject(status);
       resolve(status);
     });
   }).timeout(this.options.timeout);

--- a/test/index.js
+++ b/test/index.js
@@ -51,7 +51,17 @@ describe('Phantasma', function () {
           status.should.equal('success');
         });
     });
-    
+
+    it('should reject when open fails', function () {
+      return ph.open('http://localhost:3001')
+        .then(function (status) {
+          throw new Error('failed request did not reject');
+        })
+        .catch(function (status) {
+          status.should.equal('fail');
+        });
+    });
+
     it('should get the page title', function () {
       return ph.open('http://localhost:3000')
         .title()


### PR DESCRIPTION
Phantom's `page.open` can succeed of fail, according to [the docs](http://phantomjs.org/api/webpage/method/open.html). A `fail` status occurs when the URL can't be reached, like when the server is offline or the network is down (though, interestingly, _not_ when the statusCode >= 400).

Currently, phantasma always resolves, even on `fail` responses. This PR will cause a `reject` if the status is `fail`. This means subsequent calls on the page object (`.screenshot`, for example) will time out and obscure the real problem in any `catch` handlers.

This change causes open to reject on `fail`. I added a test as well, but it could fail if there's another server on `localhost:3001`. I'm open to writing a better failure case if you think this is a problem.
