### PR TITLE
Fix custom phantom paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ var OPTIONS = {
     'webSecurity'
   ],
   options: [
-    'phantomPath',
+    'path',
+    'binary',
     'port'
   ],
   page: [
@@ -45,7 +46,8 @@ var DEFAULTS = {
   localStoragePath: null,
   localToRemoteUrlAccess: false,
   maxDiskCacheSize: null,
-  phantomPath: null,
+  path: null,
+  binary: null,
   port: null,
   proxy: null,
   proxyType: 'http',


### PR DESCRIPTION
Removes `phantomPath` and adds `path` and `binary`, as used by [phantom](https://github.com/sgentle/phantomjs-node/blob/master/phantom.coffee#L54-L55)

Closes #27 
