### PR TITLE
Adding removeListener function.

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -39,7 +39,7 @@ module.exports = function (pa) {
   });
 
   // methods to run immediately
-  ['on', 'once', 'getPid'].forEach(function (method) {
+  ['on', 'once', 'getPid', 'removeListener'].forEach(function (method) {
     Promise.prototype[method] = function () {
       var args = [].slice.call(arguments);
       return phantasma[method].apply(phantasma, args);

--- a/readme.md
+++ b/readme.md
@@ -244,6 +244,9 @@ ph.open('https://duckduckgo.com')
 #### .once(event, callback)
 Executes `callback` when the `event` is emitted only once.
 
+#### .removeListener(event, callback)
+Removes `callback` from `event` listener.
+
 #### Supported Events:
 
 Supports the following phantomjs events, you can read more on these here ([PhantomJS callbacks](https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage#callbacks-list)):

--- a/test/index.js
+++ b/test/index.js
@@ -268,6 +268,25 @@ describe('Phantasma', function () {
         });
     });
 
+    it('should remove event listener', function (done) {
+      var count = 0;
+      var errorCallback = function (msg){
+        count++;
+        msg.should.not.be.empty;
+      }
+      ph.on('onError', errorCallback);
+      ph.open('http://localhost:3000/jserr.html')
+        .then(function(){
+          ph.removeListener('onError', errorCallback);
+        })
+        .open('http://localhost:3000/jserr.html')
+        .delay(100)
+        .then(function(){
+          count.should.equal(1);
+          done();
+        });
+    });
+
     it('should emit on navigation requested', function (done) {
       ph.open('http://localhost:3000')
         .once('onNavigationRequested', function (url, type, willNavigate, main) {


### PR DESCRIPTION
Hey Pete!

I found a use case for removing my `onError` case. I'm using Phantasma under the sheets of some software and I want to catch if an `onError` event happens and return that out to my Promise chain so I can terminate it. I did this with the following code:

``` js
return new Promise(function(resolve, reject){
    // Attach our function to the onError handler
    var onErrorCallback = function(msg, trace){
        var fullTrace = buildStackTrace(msg, trace);
        if (fullTrace.indexOf('phantomjs') > -1){
          reject(fullTrace);
        }
      };
    self.phantasma.on('onError',onErrorCallback);
    self.phantasma.evaluate.apply(self.phantasma, evalArgs)
      .then(function(result){
        // The function worked and we have a result. Remove
        // the catching function.
        self.phantasma.removeListener('onError', onErrorCallback);
        resolve(result);
      });
  })
```

I've tested in my framework and I'm no longer getting the message I was doing before, which was:

`(node) warning: possible EventEmitter memory leak detected. 11 onError listeners added. Use emitter.setMaxListeners() to increase limit.`

I'm not quite sure how to test this in the test bench you've set up. Maybe you can inform? Let me know if I can help in validating this. 
